### PR TITLE
Remove privacy account email field

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,6 +94,7 @@ const config = {
           {to: '/blog', label: 'Blog', position: 'left'},
           {to: '/donate', label: 'Donate', position: 'left'},
           {to: '/changelog', label: 'Changelog', position: 'left'},
+          {to: '/contact', label: 'Contact', position: 'left'},
           {
             href: "https://github.com/bwhybrow23",
             position: "right",
@@ -135,6 +136,15 @@ const config = {
                 label: 'Terms of Service',
                 to: '/terms',
               }
+            ],
+          },
+          {
+            title: 'Contact',
+            items: [
+              {
+                label: 'Contact Form',
+                to: '/contact',
+              },
             ],
           },
           {

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -98,6 +98,139 @@
   min-height: calc(100vh - 60px);
 }
 
+.contact-page {
+  display: grid;
+  gap: 2rem;
+}
+
+.contact-hero {
+  text-align: center;
+
+  h1 {
+    margin-bottom: 0.5rem;
+  }
+
+  p {
+    color: var(--sb-text-muted);
+    margin: 0 auto;
+    max-width: 560px;
+  }
+}
+
+.contact-form-card {
+  background: var(--sb-surface);
+  border: 1px solid var(--sb-border-color);
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+  display: grid;
+  gap: 1.5rem;
+  margin: 0 auto;
+  max-width: 720px;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+[data-theme='dark'] .contact-form-card {
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+}
+
+.contact-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.contact-field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.contact-field label {
+  font-weight: 600;
+}
+
+.contact-field label a {
+  color: var(--ifm-color-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.contact-field label a:hover {
+  text-decoration: underline;
+}
+
+.contact-field input,
+.contact-field textarea,
+.contact-field select {
+  background: var(--sb-surface-2);
+  border: 1px solid var(--sb-border-color);
+  border-radius: 12px;
+  color: inherit;
+  font-size: 1rem;
+  padding: 0.75rem 0.9rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-field input:focus,
+.contact-field textarea:focus,
+.contact-field select:focus {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 3px rgba(56, 210, 248, 0.2);
+  outline: none;
+}
+
+.contact-field input[aria-invalid='true'],
+.contact-field textarea[aria-invalid='true'],
+.contact-field select[aria-invalid='true'] {
+  border-color: #e5484d;
+  box-shadow: 0 0 0 3px rgba(229, 72, 77, 0.15);
+}
+
+.contact-helper {
+  color: var(--sb-text-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.contact-error {
+  color: #e5484d;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.contact-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.contact-field-group {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-privacy {
+  color: var(--sb-text-muted);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.contact-status {
+  border-radius: 12px;
+  background: var(--sb-surface-2);
+  color: var(--sb-text-muted);
+  margin: 0;
+  padding: 0.75rem 1rem;
+}
+
+.contact-form-card .cf-turnstile {
+  margin-top: 0.5rem;
+}
+
 //GitHub Link Header
 html[data-theme='dark'] .github-link {
   align-items: center;

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -11,6 +11,24 @@ declare global {
 export default function Contact() {
   const startedAt = useRef(Date.now());
   const [status, setStatus] = useState<string | null>(null);
+  const [errors, setErrors] = useState({
+    name: "",
+    email: "",
+    topic: "",
+    message: "",
+    docUrl: "",
+    docDetails: "",
+    command: "",
+    botDetails: "",
+    botDiscordUsername: "",
+    botDiscordId: "",
+    privacyType: "",
+    privacyDiscordUsername: "",
+    privacyDiscordId: "",
+    turnstile: "",
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [topic, setTopic] = useState("");
 
   useEffect(() => {
     window.onTurnstileSuccess = (token: string) => {
@@ -23,18 +41,134 @@ export default function Contact() {
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setStatus("Sending...");
+    setStatus(null);
 
     const form = e.currentTarget;
     const formData = new FormData(form);
+    const name = String(formData.get("name") || "").trim();
+    const email = String(formData.get("email") || "").trim();
+    const topicValue = String(formData.get("topic") || "").trim();
+    const message = String(formData.get("message") || "").trim();
+    const docUrl = String(formData.get("docUrl") || "").trim();
+    const docDetails = String(formData.get("docDetails") || "").trim();
+    const command = String(formData.get("command") || "").trim();
+    const botDetails = String(formData.get("botDetails") || "").trim();
+    const botDiscordUsername = String(formData.get("botDiscordUsername") || "").trim();
+    const botDiscordId = String(formData.get("botDiscordId") || "").trim();
+    const privacyType = String(formData.get("privacyType") || "").trim();
+    const privacyDiscordUsername = String(formData.get("privacyDiscordUsername") || "").trim();
+    const privacyDiscordId = String(formData.get("privacyDiscordId") || "").trim();
+    const turnstileToken = window.turnstileToken || "";
+    const nextErrors = {
+      name: "",
+      email: "",
+      topic: "",
+      message: "",
+      docUrl: "",
+      docDetails: "",
+      command: "",
+      botDetails: "",
+      botDiscordUsername: "",
+      botDiscordId: "",
+      privacyType: "",
+      privacyDiscordUsername: "",
+      privacyDiscordId: "",
+      turnstile: "",
+    };
+
+    if (name.length < 2) nextErrors.name = "Please enter at least 2 characters.";
+    if (name.length > 80) nextErrors.name = "Please keep your name under 80 characters.";
+
+    if (!email) {
+      nextErrors.email = "Please enter your email address.";
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      nextErrors.email = "Please enter a valid email address.";
+    }
+
+    if (!topicValue) nextErrors.topic = "Please choose a topic.";
+
+    if (message.length < 10) nextErrors.message = "Please add at least 10 characters.";
+    if (message.length > 1000) nextErrors.message = "Please keep your message under 1000 characters.";
+
+    if (topicValue === "documentation") {
+      if (!docUrl) nextErrors.docUrl = "Please share the docs page URL.";
+      if (docDetails.length < 10) nextErrors.docDetails = "Please add a few details about the issue.";
+    }
+
+    if (topicValue === "bot-issue") {
+      if (!command) nextErrors.command = "Please share the command you used.";
+      if (botDetails.length < 10) nextErrors.botDetails = "Please add a few details about the issue.";
+      if (!botDiscordUsername) nextErrors.botDiscordUsername = "Please add your Discord username.";
+      if (!botDiscordId) nextErrors.botDiscordId = "Please add your Discord ID.";
+    }
+
+    if (topicValue === "privacy") {
+      if (!privacyType) nextErrors.privacyType = "Please select a privacy request type.";
+      if (!privacyDiscordUsername) nextErrors.privacyDiscordUsername = "Please add your Discord username.";
+      if (!privacyDiscordId) nextErrors.privacyDiscordId = "Please add your Discord ID.";
+    }
+
+    if (document.querySelector(".cf-turnstile") && !turnstileToken) {
+      nextErrors.turnstile = "Please complete the verification.";
+    }
+
+    if (
+      nextErrors.name ||
+      nextErrors.email ||
+      nextErrors.topic ||
+      nextErrors.message ||
+      nextErrors.docUrl ||
+      nextErrors.docDetails ||
+      nextErrors.command ||
+      nextErrors.botDetails ||
+      nextErrors.botDiscordUsername ||
+      nextErrors.botDiscordId ||
+      nextErrors.privacyType ||
+      nextErrors.privacyDiscordUsername ||
+      nextErrors.privacyDiscordId ||
+      nextErrors.turnstile
+    ) {
+      setErrors(nextErrors);
+      setStatus("Please fix the highlighted fields.");
+      return;
+    }
+
+    setErrors({
+      name: "",
+      email: "",
+      topic: "",
+      message: "",
+      docUrl: "",
+      docDetails: "",
+      command: "",
+      botDetails: "",
+      botDiscordUsername: "",
+      botDiscordId: "",
+      privacyType: "",
+      privacyDiscordUsername: "",
+      privacyDiscordId: "",
+      turnstile: "",
+    });
+    setStatus("Sending...");
+    setIsSubmitting(true);
 
     const payload = {
-      name: String(formData.get("name") || ""),
-      email: String(formData.get("email") || ""),
-      message: String(formData.get("message") || ""),
+      name,
+      email,
+      topic: topicValue,
+      message,
+      docUrl,
+      docDetails,
+      command,
+      botDetails,
+      botDiscordUsername,
+      botDiscordId,
+      privacyType,
+      privacyDiscordUsername,
+      privacyDiscordId,
       website: String(formData.get("website") || ""), // honeypot
       startedAt: startedAt.current,
-      turnstileToken: window.turnstileToken || "",
+      turnstileToken,
     };
 
     const endpoint =
@@ -42,44 +176,320 @@ export default function Contact() {
         ? "https://stenbot.benwhybrow.com/api/contact"
         : "/api/contact";
 
-    const res = await fetch(endpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
 
-    setStatus(res.ok ? "Sent!" : "Error. Please try again.");
-    if (res.ok) form.reset();
+      setStatus(res.ok ? "Sent! We'll be in touch soon." : "Error. Please try again.");
+      if (res.ok) {
+        form.reset();
+        window.turnstileToken = "";
+        setTopic("");
+      }
+    } catch (error) {
+      setStatus("Error. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   return (
     <Layout title="Contact">
-      <main className="container margin-vert--lg">
-        <h1>Contact</h1>
+      <main className="container margin-vert--lg contact-page">
+        <div className="contact-hero">
+          <h1>Contact</h1>
+          <p>Tell us what you need and we'll get back to you within 1-2 business days.</p>
+        </div>
 
-        <form onSubmit={onSubmit}>
+        <form className="contact-form-card" onSubmit={onSubmit} noValidate>
           {/* honeypot */}
           <input type="text" name="website" style={{ display: "none" }} tabIndex={-1} autoComplete="off" />
 
-          <div className="margin-bottom--md">
-            <label>
-              Name
-              <input name="name" required />
-            </label>
+          <div className="contact-grid">
+            <div className="contact-field">
+              <label htmlFor="contact-name">Name</label>
+              <input
+                id="contact-name"
+                name="name"
+                autoComplete="name"
+                minLength={2}
+                maxLength={80}
+                required
+                aria-invalid={Boolean(errors.name)}
+                aria-describedby={errors.name ? "contact-name-error" : undefined}
+              />
+              {errors.name && (
+                <p className="contact-error" id="contact-name-error">
+                  {errors.name}
+                </p>
+              )}
+            </div>
+
+            <div className="contact-field">
+              <label htmlFor="contact-email">Email</label>
+              <input
+                id="contact-email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                aria-invalid={Boolean(errors.email)}
+                aria-describedby={errors.email ? "contact-email-error" : undefined}
+              />
+              {errors.email && (
+                <p className="contact-error" id="contact-email-error">
+                  {errors.email}
+                </p>
+              )}
+            </div>
           </div>
 
-          <div className="margin-bottom--md">
-            <label>
-              Email
-              <input name="email" type="email" required />
-            </label>
+          <div className="contact-field">
+            <label htmlFor="contact-topic">What can we help with?</label>
+            <select
+              id="contact-topic"
+              name="topic"
+              required
+              value={topic}
+              onChange={(event) => setTopic(event.target.value)}
+              aria-invalid={Boolean(errors.topic)}
+              aria-describedby={errors.topic ? "contact-topic-error" : "contact-topic-help"}
+            >
+              <option value="">Select a topic</option>
+              <option value="documentation">Report incorrect documentation</option>
+              <option value="bot-issue">Report an issue with the bot</option>
+              <option value="privacy">Privacy request (UK GDPR)</option>
+            </select>
+            <p className="contact-helper" id="contact-topic-help">
+              We'll ask a few follow-up questions based on your choice.
+            </p>
+            {errors.topic && (
+              <p className="contact-error" id="contact-topic-error">
+                {errors.topic}
+              </p>
+            )}
           </div>
 
-          <div className="margin-bottom--md">
-            <label>
-              Message
-              <textarea name="message" rows={6} required />
-            </label>
+          {topic === "documentation" && (
+            <div className="contact-field-group">
+              <div className="contact-field">
+                <label htmlFor="contact-doc-url">Docs page URL</label>
+                <input
+                  id="contact-doc-url"
+                  name="docUrl"
+                  type="url"
+                  placeholder="https://stenbot.benwhybrow.com/docs/..."
+                  aria-invalid={Boolean(errors.docUrl)}
+                  aria-describedby={errors.docUrl ? "contact-doc-url-error" : undefined}
+                  required
+                />
+                {errors.docUrl && (
+                  <p className="contact-error" id="contact-doc-url-error">
+                    {errors.docUrl}
+                  </p>
+                )}
+              </div>
+              <div className="contact-field">
+                <label htmlFor="contact-doc-details">What's incorrect?</label>
+                <textarea
+                  id="contact-doc-details"
+                  name="docDetails"
+                  rows={4}
+                  minLength={10}
+                  required
+                  aria-invalid={Boolean(errors.docDetails)}
+                  aria-describedby={errors.docDetails ? "contact-doc-details-error" : undefined}
+                />
+                {errors.docDetails && (
+                  <p className="contact-error" id="contact-doc-details-error">
+                    {errors.docDetails}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {topic === "bot-issue" && (
+            <div className="contact-field-group">
+              <div className="contact-grid">
+                <div className="contact-field">
+                  <label htmlFor="contact-bot-discord-username">Discord username</label>
+                  <input
+                    id="contact-bot-discord-username"
+                    name="botDiscordUsername"
+                    placeholder="username or username#0000"
+                    aria-invalid={Boolean(errors.botDiscordUsername)}
+                    aria-describedby={errors.botDiscordUsername ? "contact-bot-discord-username-error" : undefined}
+                    required
+                  />
+                  {errors.botDiscordUsername && (
+                    <p className="contact-error" id="contact-bot-discord-username-error">
+                      {errors.botDiscordUsername}
+                    </p>
+                  )}
+                </div>
+                <div className="contact-field">
+                  <label htmlFor="contact-bot-discord-id">
+                    Discord ID (
+                    <a
+                      href="https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      how to find it
+                    </a>
+                    )
+                  </label>
+                  <input
+                    id="contact-bot-discord-id"
+                    name="botDiscordId"
+                    inputMode="numeric"
+                    placeholder="123456789012345678"
+                    aria-invalid={Boolean(errors.botDiscordId)}
+                    aria-describedby={errors.botDiscordId ? "contact-bot-discord-id-error" : undefined}
+                    required
+                  />
+                  {errors.botDiscordId && (
+                    <p className="contact-error" id="contact-bot-discord-id-error">
+                      {errors.botDiscordId}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="contact-field">
+                <label htmlFor="contact-command">Command used</label>
+                <input
+                  id="contact-command"
+                  name="command"
+                  placeholder="/command or !command"
+                  aria-invalid={Boolean(errors.command)}
+                  aria-describedby={errors.command ? "contact-command-error" : undefined}
+                  required
+                />
+                {errors.command && (
+                  <p className="contact-error" id="contact-command-error">
+                    {errors.command}
+                  </p>
+                )}
+              </div>
+              <div className="contact-field">
+                <label htmlFor="contact-bot-details">What happened?</label>
+                <textarea
+                  id="contact-bot-details"
+                  name="botDetails"
+                  rows={4}
+                  minLength={10}
+                  required
+                  aria-invalid={Boolean(errors.botDetails)}
+                  aria-describedby={errors.botDetails ? "contact-bot-details-error" : undefined}
+                />
+                {errors.botDetails && (
+                  <p className="contact-error" id="contact-bot-details-error">
+                    {errors.botDetails}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {topic === "privacy" && (
+            <div className="contact-field-group">
+              <div className="contact-grid">
+                <div className="contact-field">
+                  <label htmlFor="contact-privacy-discord-username">Discord username</label>
+                  <input
+                    id="contact-privacy-discord-username"
+                    name="privacyDiscordUsername"
+                    placeholder="username or username#0000"
+                    aria-invalid={Boolean(errors.privacyDiscordUsername)}
+                    aria-describedby={
+                      errors.privacyDiscordUsername ? "contact-privacy-discord-username-error" : undefined
+                    }
+                    required
+                  />
+                  {errors.privacyDiscordUsername && (
+                    <p className="contact-error" id="contact-privacy-discord-username-error">
+                      {errors.privacyDiscordUsername}
+                    </p>
+                  )}
+                </div>
+                <div className="contact-field">
+                  <label htmlFor="contact-privacy-discord-id">
+                    Discord ID (
+                    <a
+                      href="https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      how to find it
+                    </a>
+                    )
+                  </label>
+                  <input
+                    id="contact-privacy-discord-id"
+                    name="privacyDiscordId"
+                    inputMode="numeric"
+                    placeholder="123456789012345678"
+                    aria-invalid={Boolean(errors.privacyDiscordId)}
+                    aria-describedby={errors.privacyDiscordId ? "contact-privacy-discord-id-error" : undefined}
+                    required
+                  />
+                  {errors.privacyDiscordId && (
+                    <p className="contact-error" id="contact-privacy-discord-id-error">
+                      {errors.privacyDiscordId}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="contact-field">
+                <label htmlFor="contact-privacy-type">Request type</label>
+                <select
+                  id="contact-privacy-type"
+                  name="privacyType"
+                  required
+                  aria-invalid={Boolean(errors.privacyType)}
+                  aria-describedby={errors.privacyType ? "contact-privacy-type-error" : undefined}
+                >
+                  <option value="">Select a request</option>
+                  <option value="access">Access my data</option>
+                  <option value="delete">Delete my data</option>
+                  <option value="correction">Correct my data</option>
+                  <option value="restriction">Restrict processing</option>
+                  <option value="other">Other privacy request</option>
+                </select>
+                {errors.privacyType && (
+                  <p className="contact-error" id="contact-privacy-type-error">
+                    {errors.privacyType}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div className="contact-field">
+            <label htmlFor="contact-message">Message</label>
+            <textarea
+              id="contact-message"
+              name="message"
+              rows={6}
+              minLength={10}
+              maxLength={1000}
+              required
+              aria-invalid={Boolean(errors.message)}
+              aria-describedby={errors.message ? "contact-message-error" : undefined}
+            />
+            <div className="contact-helper">
+              <span>Share a few details so we can help quickly.</span>
+              <span>10-1000 characters</span>
+            </div>
+            {errors.message && (
+              <p className="contact-error" id="contact-message-error">
+                {errors.message}
+              </p>
+            )}
           </div>
 
           <div
@@ -88,11 +498,16 @@ export default function Contact() {
             data-callback="onTurnstileSuccess"
           />
 
-          <button className="button button--primary" type="submit">
-            Send
-          </button>
+          {errors.turnstile && <p className="contact-error">{errors.turnstile}</p>}
 
-          {status && <p className="margin-top--md">{status}</p>}
+          <div className="contact-actions">
+            <button className="button button--primary" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Sending..." : "Send"}
+            </button>
+            <p className="contact-privacy">We only use your info to respond to your request.</p>
+          </div>
+
+          {status && <p className="contact-status">{status}</p>}
         </form>
       </main>
     </Layout>

--- a/src/pages/privacy.mdx
+++ b/src/pages/privacy.mdx
@@ -14,9 +14,7 @@ This privacy notice for StenBot ('**Company**', '**we**', '**us**', or '**our**'
 - Use our Discord chatbot (StenBot), or any other application of ours that links to this privacy notice (e.g., API, Website)
 - Engage with us in other related ways, including any sales, marketing, or events
 
-**Questions or concerns?** Reading this privacy notice will help you understand your privacy rights and choices. If you do not agree with our policies and practices, please do not use our Services. If you still have any questions or concerns, please contact us at **stenbot@alias.bens.sh**.
-
-**_Please note that currently there are issues with our email system, so the email has been changed in the privacy policy to a gmail address that is monitored daily. We apologise for the inconvenience._**
+**Questions or concerns?** Reading this privacy notice will help you understand your privacy rights and choices. If you do not agree with our policies and practices, please do not use our Services. If you still have any questions or concerns, please use our [contact form](/contact).
 
 ## Summary of Key Points
 
@@ -36,7 +34,7 @@ This privacy notice for StenBot ('**Company**', '**we**', '**us**', or '**our**'
 
 **What are your rights?** Depending on where you are located geographically, the applicable privacy law may mean you have certain rights regarding your personal information. Click [here](#what-are-your-privacy-rights) to learn more.
 
-**How do you exercise your rights?** The easiest way to exercise your rights is by emailing us using the email at the bottom of the page. We will consider and act upon any request in accordance with applicable data protection laws.
+**How do you exercise your rights?** The easiest way to exercise your rights is by submitting our [contact form](/contact). We will consider and act upon any request in accordance with applicable data protection laws.
 
 Want to learn more about what StenBot does with any information we collect? Click [here](#table-of-contents) to review the notice in full.
 
@@ -192,7 +190,7 @@ Upon your request to terminate your account, we will deactivate or delete your a
 
 **_Cookies and similar technologies:_** Most Web browsers are set to accept cookies by default. If you prefer, you can usually choose to set your browser to remove cookies and to reject cookies. If you choose to remove cookies or reject cookies, this could affect certain features or services of our Services. To opt out of interest-based advertising by advertisers on our Services visit [http://www.aboutads.info/choices/](http://www.aboutads.info/choices/).
 
-If you have questions or comments about your privacy rights, you may email us at **stenbot@alias.bens.sh**.
+If you have questions or comments about your privacy rights, please use our [contact form](/contact).
 
 ## Controls for Do-Not-Track Features
 
@@ -245,7 +243,7 @@ We may also collect other personal information outside of these categories throu
 
 More information about our data collection and sharing practices can be found in this privacy notice.
 
-You may contact us by email at **stenbot@alias.bens.sh**, or by referring to the contact details at the bottom of this document.
+You may contact us via our [contact form](/contact), or by referring to the contact details at the bottom of this document.
 
 If you are using an authorised agent to exercise your right to opt out we may deny a request if the authorised agent does not submit proof that they have been validly authorised to act on your behalf.
 
@@ -294,7 +292,7 @@ We will only use personal information provided in your request to verify your id
 - You can designate an authorised agent to make a request under the CCPA on your behalf. We may deny a request from an authorised agent that does not submit proof that they have been validly authorised to act on your behalf in accordance with the CCPA.
 - You may request to opt out from future selling of your personal information to third parties. Upon receiving an opt-out request, we will act upon the request as soon as feasibly possible, but no later than fifteen (15) days from the date of the request submission.
 
-To exercise these rights, you can contact us by email at **stenbot@alias.bens.sh**, or by referring to the contact details at the bottom of this document. If you have a complaint about how we handle your data, we would like to hear from you.
+To exercise these rights, you can contact us via our [contact form](/contact), or by referring to the contact details at the bottom of this document. If you have a complaint about how we handle your data, we would like to hear from you.
 
 ## Do we make updates to this notice?
 
@@ -304,8 +302,8 @@ We may update this privacy notice from time to time. The updated version will be
 
 ## How can you contact us about this notice?
 
-If you have questions or comments about this notice, you may email us at **stenbot@alias.bens.sh**
+If you have questions or comments about this notice, please use our [contact form](/contact).
 
 ## How can you review, update, or delete the data we collect from you?
 
-Based on the applicable laws of your country, you may have the right to request access to the personal information we collect from you, change that information, or delete it in some circumstances. To request to review, update, or delete your personal information, please email **stenbot@alias.bens.sh**. We aim to respond to your request within 30 days.
+Based on the applicable laws of your country, you may have the right to request access to the personal information we collect from you, change that information, or delete it in some circumstances. To request to review, update, or delete your personal information, please use our [contact form](/contact). We aim to respond to your request within 30 days.

--- a/src/pages/terms.mdx
+++ b/src/pages/terms.mdx
@@ -11,9 +11,7 @@ These Terms of Service ("**Terms**", "**Agreement**") govern your access to and 
 
 By using our services ("**Services**"), you agree to be bound by these Terms. If you do not agree to these Terms, you may not access or use the Services.
 
-For questions or concerns, you can contact us at **ben@benwhybrow.com**.
-
-_**Please note:** If you experience issues contacting this address, please use our monitored alternative: **benwhybrow@gmail.com**._
+For questions or concerns, please use our [contact form](/contact).
 
 ## Summary of Key Points
 
@@ -81,4 +79,4 @@ These Terms shall be governed and construed in accordance with the laws of the U
 
 ## Contact Information
 
-If you have questions or concerns about these Terms, please contact us at **stenbot@alias.bens.sh**.
+If you have questions or concerns about these Terms, please use our [contact form](/contact).


### PR DESCRIPTION
### Motivation
- Privacy requests for the Discord bot should not require an account email; verification can be performed using Discord identifiers and the centralized contact form.

### Description
- Removed the `privacyEmail` input, related state, validation, and payload usage from `src/pages/contact.tsx` so privacy requests no longer include or require an account email.
- Simplified privacy validation to rely on `privacyDiscordUsername` and `privacyDiscordId` and preserved Turnstile verification and submission state handling (`isSubmitting`, status messaging).
- Kept the existing contact submission flow and payload structure while removing the email field from the privacy-specific branch.

### Testing
- Ran `npm run start -- --host 0.0.0.0 --port 3000` and confirmed the dev server started and client compiled successfully (succeeded).
- Executed a Playwright script that opened `/contact`, selected the `privacy` topic, and saved `artifacts/contact-form-privacy.png` to validate the UI change (succeeded).
- Verified `privacyEmail` no longer appears in `src/pages/contact.tsx` using a code search (`rg`) (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698648b7b6848321a1531f6f9f588d25)